### PR TITLE
WIP makes flaskerizer parse entire bootstrap template to detect js,css, etc rather than having user point to their directories manually

### DIFF
--- a/Flaskerizer_src/Tests/test_gui_for_flaskerizer.py
+++ b/Flaskerizer_src/Tests/test_gui_for_flaskerizer.py
@@ -16,15 +16,12 @@ class TestGUI(unittest.TestCase):
         functional.
         """
         self.assertEqual(self.test.get_values(),
-                         ["Select one HTML (.html) file from the template",
-         "Select the template folder containing all the css, img, js folders",
-         "Select one JavaScript (.js) file from the template JavaScript folder"])
-        self.test.html_location.set("Html Location")
-        self.test.static_location.set("Static Location")
-        self.test.js_location.set("JS Location")
+                         ["Select one HTML file from the main HTML folder of the Bootstrap template",
+                          "Select the 'top level' folder of the Bootstrap template"])
+        self.test.templates_path.set("Templates Path Location")
+        self.test.top_level_path.set("Top Level Path Location")
         self.assertEqual(self.test.get_values(),
-                         ['Html Location', "Static Location",
-         "JS Location"])
+                         ['Templates Path Location', "Top Level Path Location"])
 
     def test_path(self):
         """Gives two file paths to the path_to_folder function in ChooseFilesGUI

--- a/Flaskerizer_src/Tests/test_structure_directory.py
+++ b/Flaskerizer_src/Tests/test_structure_directory.py
@@ -13,78 +13,55 @@ class TestStructureDirectory(unittest.TestCase):
         '''Instantiates an object 'test' from the StructureDirectory class.
         '''
         self.test = StructureDirectory(templates_path=CONFIGURATION['templates_path'],
-                                       static_path=CONFIGURATION['static_path'],
-                                       javascript_path=CONFIGURATION['javascript_path'])
+                                       top_level_path=CONFIGURATION['top_level_path'])
+
 
     def test_mkdir(self):
-        '''Tests that mkdir creates a folder named static and a folder named templates.
+        '''Tests that mkdir creates a folder named static and a folder named templates. Also test that the subfolders
+        of static "css, fons, img, and js" are created.
         '''
-        self.test.mkdir('static')
-        self.test.mkdir('templates')
+        self.test.mkdir()
         self.assertTrue(os.path.exists(os.path.join(os.path.dirname(flaskerizer.__file__),
                                                     os.path.basename('Flaskerized_app'),
                                                     os.path.basename('static'))))
         self.assertTrue(os.path.exists(os.path.join(os.path.dirname(flaskerizer.__file__),
                                                     os.path.basename('Flaskerized_app'),
+                                                    os.path.basename('static'),
+                                                    os.path.basename('css'))))
+        self.assertTrue(os.path.exists(os.path.join(os.path.dirname(flaskerizer.__file__),
+                                                    os.path.basename('Flaskerized_app'),
+                                                    os.path.basename('static'),
+                                                    os.path.basename('fonts'))))
+        self.assertTrue(os.path.exists(os.path.join(os.path.dirname(flaskerizer.__file__),
+                                                    os.path.basename('Flaskerized_app'),
+                                                    os.path.basename('static'),
+                                                    os.path.basename('img'))))
+        self.assertTrue(os.path.exists(os.path.join(os.path.dirname(flaskerizer.__file__),
+                                                    os.path.basename('Flaskerized_app'),
+                                                    os.path.basename('static'),
+                                                    os.path.basename('js'))))
+        self.assertTrue(os.path.exists(os.path.join(os.path.dirname(flaskerizer.__file__),
+                                                    os.path.basename('Flaskerized_app'),
                                                     os.path.basename('templates'))))
 
-    def test_migrate_static(self):
-        '''Tests that migrate_static migrates the correct number of folders from the bootstrap template directory to
-        the static directory of the Flask app.
+    def test_migrate_files(self):
+        '''Tests that migrate_files migrates the correct number of files from the bootstrap template directory to
+        the Flask app.
         '''
-        source_directory = os.path.dirname(Example.__file__)
-        write_directory = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                       os.path.basename('Flaskerized_app'),
-                                       os.path.basename('static'))
-        self.test.migrate_static()
-        source_dir_list = []
-        write_dir_list = []
-        for folder in os.listdir(source_directory):
-            if os.path.isdir(folder):
-                source_dir_list.append(folder)
-        for folder in os.listdir(write_directory):
-            if os.path.isdir(folder):
-                write_dir_list.append(folder)
-        self.assertEqual(len(source_dir_list), len(write_dir_list))
+        migrate_dict = self.test.detect_static_files()
+        self.test.migrate_files(migrate_dict)
+        file_list = []
+        extensions = ['.js', '.css', '.jpg', '.png', 'gif', '.ico', '.otf', '.eot', '.svg', '.ttf', '.woff', '.woff2']
+        directory = os.path.join(os.path.dirname(flaskerizer.__file__),
+                                 os.path.basename('Flaskerized_app'))
+        for path, subdir, files in os.walk(directory):
+            for name in files:
+                for extension in extensions:
+                    if name.endswith(extension):
+                        file_list.append(name)
+        self.assertEqual(136, len(file_list))
 
-    def test_parse_html(self):
-        ''' Tests that parse_html creates a file 'index.html' in a templates folder that matches a "gold standard"
-         version of 'index.html' called 'index_test_file.html'.
-        '''
-        self.test.migrate_static()         # to make all the tests independent. Tests are run in random order
-        self.test.parse_html()
-        html_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                os.path.basename('Flaskerized_app'),
-                                os.path.basename('templates'),
-                                os.path.basename('index.html'))
-        with open(html_dir, 'r') as test_obj:
-            test_string = test_obj.read()
-        test_dir = os.path.join(os.path.dirname(Tests.__file__),
-                                        os.path.basename('testing_files'),
-                                        os.path.basename('index_test_file.html'))
-        with open(test_dir) as gold_obj:
-            gold_string = gold_obj.read()
-        self.assertMultiLineEqual(test_string, gold_string)
 
-    def test_parse_javascript(self):
-        ''' Tests that parse_javascript creates a file 'custom.js' in the static/js folder that matches a
-        "gold standard" version of 'custom.js' called 'custom_test_file.js'.
-        '''
-        self.test.migrate_static()
-        self.test.parse_javascript()
-        js_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
-                              os.path.basename('Flaskerized_app'),
-                              os.path.basename('static'),
-                              os.path.basename('js'),
-                              os.path.basename('custom.js'))
-        with open(js_dir, 'r') as test_obj:
-            test_string = test_obj.read()
-        test_dir = os.path.join(os.path.dirname(Tests.__file__),
-                                        os.path.basename('testing_files'),
-                                        os.path.basename('custom_test_file.js'))
-        with open(test_dir) as gold_obj:
-            gold_string = gold_obj.read()
-        self.assertMultiLineEqual(test_string, gold_string)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Flaskerizer_src/Tests/test_structure_directory.py
+++ b/Flaskerizer_src/Tests/test_structure_directory.py
@@ -59,7 +59,7 @@ class TestStructureDirectory(unittest.TestCase):
                 for extension in extensions:
                     if name.endswith(extension):
                         file_list.append(name)
-        self.assertEqual(136, len(file_list))
+        self.assertEqual(135, len(file_list))
 
 
 

--- a/Flaskerizer_src/Tests/test_structure_directory.py
+++ b/Flaskerizer_src/Tests/test_structure_directory.py
@@ -59,7 +59,7 @@ class TestStructureDirectory(unittest.TestCase):
                 for extension in extensions:
                     if name.endswith(extension):
                         file_list.append(name)
-        self.assertEqual(135, len(file_list))
+        self.assertEqual(136, len(file_list))
 
 
 

--- a/Flaskerizer_src/Tests/test_write_app.py
+++ b/Flaskerizer_src/Tests/test_write_app.py
@@ -14,10 +14,8 @@ class TestWriteApp(unittest.TestCase):
         also instantiated from the WriteApp class.
         '''
         structure_directory_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'],
-                                                        static_path=CONFIGURATION['static_path'],
-                                                        javascript_path=CONFIGURATION['javascript_path'])
-        structure_directory_object.migrate_static()
-        structure_directory_object.parse_html()
+                                                        top_level_path=CONFIGURATION['top_level_path'])
+        structure_directory_object.structure_directory()
         self.test = WriteApp()
 
     def test_get_routes(self):

--- a/Flaskerizer_src/Tests/testing_files/index_test_file.html
+++ b/Flaskerizer_src/Tests/testing_files/index_test_file.html
@@ -8,9 +8,9 @@
   <!-- css -->
   <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700|Open+Sans:400,300,700,800" rel="stylesheet" media="screen">
 
-  <link href="/static/css/bootstrap.min.css" rel="stylesheet" media="screen">
-  <link href="/static/css/style.css" rel="stylesheet" media="screen">
-  <link href="/static/color/default.css" rel="stylesheet" media="screen">
+  <link href="static/css/023283bootstrap.min.css" rel="stylesheet" media="screen">
+  <link href="static/css/014289style.css" rel="stylesheet" media="screen">
+  <link href="static/css/009431default.css" rel="stylesheet" media="screen">
 
   <!-- =======================================================
     Theme Name: Alstar
@@ -79,7 +79,7 @@
       </div>
       <div class="row wow fadeInUp">
         <div class="col-md-6 about-img">
-          <img src="/static/img/about-img.jpg" alt="">
+          <img src="static/img/024465about-img.jpg" alt="">
         </div>
 
         <div class="col-md-6 content">
@@ -135,7 +135,7 @@
                   </div>
                   <div class="col-sm-12 col-md-5">
                     <div class="screenshot wow bounceInRight">
-                      <img src="/static/img/screenshots/1.png" class="img-responsive" alt="" />
+                      <img src="static/img/0658491.png" class="img-responsive" alt="" />
                     </div>
                   </div>
                 </div>
@@ -150,7 +150,7 @@
                   </div>
                   <div class="col-sm-12 col-md-5">
                     <div class="screenshot wow bounceInRight">
-                      <img src="/static/img/screenshots/2.png" class="img-responsive" alt="" />
+                      <img src="static/img/0343872.png" class="img-responsive" alt="" />
                     </div>
                   </div>
                 </div>
@@ -165,7 +165,7 @@
                   </div>
                   <div class="col-sm-12 col-md-5">
                     <div class="screenshot wow bounceInRight">
-                      <img src="/static/img/screenshots/3.png" class="img-responsive" alt="" />
+                      <img src="static/img/0839393.png" class="img-responsive" alt="" />
                     </div>
                   </div>
                 </div>
@@ -201,63 +201,63 @@
 
           <ul id="og-grid" class="og-grid">
             <li>
-              <a href="#" data-largesrc="/static/img/works/1.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei. Pri consul detracto eu, solet nusquam accusam ex vim, an movet interesset necessitatibus mea.">
-								<img src="/static/img/works/thumbs/1.jpg" alt=""/>
+              <a href="#" data-largesrc="static/img/0720881.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei. Pri consul detracto eu, solet nusquam accusam ex vim, an movet interesset necessitatibus mea.">
+								<img src="static/img/0556781.jpg" alt=""/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/2.jpg" data-title="Portfolio title" data-description="Mea an eros periculis dignissim, quo mollis nostrum elaboraret et. Id quem perfecto mel, no etiam perfecto qui. No nisl legere recusabo nam, ius an tale pericula evertitur, dicat phaedrum qui in. Usu numquam legendos in, voluptaria sadipscing ut vel. Eu eum mandamus volutpat gubergren, eos ad detracto nominati, ne eum idque elitr aliquam.">
-								<img src="/static/img/works/thumbs/2.jpg" alt=""/>
+              <a href="#" data-largesrc="static/img/0072132.jpg" data-title="Portfolio title" data-description="Mea an eros periculis dignissim, quo mollis nostrum elaboraret et. Id quem perfecto mel, no etiam perfecto qui. No nisl legere recusabo nam, ius an tale pericula evertitur, dicat phaedrum qui in. Usu numquam legendos in, voluptaria sadipscing ut vel. Eu eum mandamus volutpat gubergren, eos ad detracto nominati, ne eum idque elitr aliquam.">
+								<img src="static/img/0886362.jpg" alt=""/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/3.jpg" data-title="Portfolio title" data-description="Vim ad persecuti appellantur. Eam ignota deterruisset eu, in omnis fierent convenire sed. Ne nulla veritus vel, liber euripidis in eos. Postea comprehensam vis in, detracto deseruisse mei ea. Ex sadipscing deterruisset concludaturque quo.">
-								<img src="/static/img/works/thumbs/3.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0880463.jpg" data-title="Portfolio title" data-description="Vim ad persecuti appellantur. Eam ignota deterruisset eu, in omnis fierent convenire sed. Ne nulla veritus vel, liber euripidis in eos. Postea comprehensam vis in, detracto deseruisse mei ea. Ex sadipscing deterruisset concludaturque quo.">
+								<img src="static/img/0197853.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/4.jpg" data-title="Portfolio title" data-description="In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei. Pri consul detracto eu, solet nusquam accusam ex vim, an movet interesset necessitatibus mea.">
-								<img src="/static/img/works/thumbs/4.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0353844.jpg" data-title="Portfolio title" data-description="In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei. Pri consul detracto eu, solet nusquam accusam ex vim, an movet interesset necessitatibus mea.">
+								<img src="static/img/0709794.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/5.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea">
-								<img src="/static/img/works/thumbs/5.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0060715.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea">
+								<img src="static/img/0626475.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/6.jpg" data-title="Portfolio title" data-description="Id elit saepe pro. In atomorum constituam definitionem quo, at torquatos sadipscing eum, ut eum wisi meis mentitum. Probo feugiat ea duo. An usu platonem instructior, qui dolores inciderint ad. Te elit essent mea, vim ne atqui legimus invenire, ad dolor vitae sea.">
-								<img src="/static/img/works/thumbs/6.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0664366.jpg" data-title="Portfolio title" data-description="Id elit saepe pro. In atomorum constituam definitionem quo, at torquatos sadipscing eum, ut eum wisi meis mentitum. Probo feugiat ea duo. An usu platonem instructior, qui dolores inciderint ad. Te elit essent mea, vim ne atqui legimus invenire, ad dolor vitae sea.">
+								<img src="static/img/0532866.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/7.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei.">
-								<img src="/static/img/works/thumbs/7.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0111647.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei.">
+								<img src="static/img/0206877.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/8.jpg" data-title="Portfolio title" data-description="No nisl legere recusabo nam, ius an tale pericula evertitur, dicat phaedrum qui in. Usu numquam legendos in, voluptaria sadipscing ut vel. Eu eum mandamus volutpat gubergren, eos ad detracto nominati, ne eum idque elitr aliquam.">
-								<img src="/static/img/works/thumbs/8.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0782418.jpg" data-title="Portfolio title" data-description="No nisl legere recusabo nam, ius an tale pericula evertitur, dicat phaedrum qui in. Usu numquam legendos in, voluptaria sadipscing ut vel. Eu eum mandamus volutpat gubergren, eos ad detracto nominati, ne eum idque elitr aliquam.">
+								<img src="static/img/0975018.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/9.jpg" data-title="Portfolio title" data-description="Lorem ipsum dolor sit amet, ex pri quod ferri fastidii. Mazim philosophia eum ad, facilisis laboramus te est. Eam magna fabellas ut. Ne vis diceret accumsan salutandi, pro in impedit accusamus dissentias, ut nonumy eloquentiam ius.">
-								<img src="/static/img/works/thumbs/9.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/0956019.jpg" data-title="Portfolio title" data-description="Lorem ipsum dolor sit amet, ex pri quod ferri fastidii. Mazim philosophia eum ad, facilisis laboramus te est. Eam magna fabellas ut. Ne vis diceret accumsan salutandi, pro in impedit accusamus dissentias, ut nonumy eloquentiam ius.">
+								<img src="static/img/0731649.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/10.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei. Pri consul detracto eu, solet nusquam accusam ex vim.">
-								<img src="/static/img/works/thumbs/10.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/09455710.jpg" data-title="Portfolio title" data-description="Duo te dico volutpat, unum elit oblique per id. Ne duo mollis sapientem intellegebat. Per at augue vidisse percipit, pri vocibus assueverit interesset ut, no dolore luptatum incorrupte nec. In mentitum forensibus nec, nibh eripuit ut pri, tale illud voluptatum ut sea. Sed oratio repudiare ei, cum an magna labitur, eu atqui augue mei. Pri consul detracto eu, solet nusquam accusam ex vim.">
+								<img src="static/img/03913110.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/11.jpg" data-title="Portfolio title" data-description="Vim ad persecuti appellantur. Eam ignota deterruisset eu, in omnis fierent convenire sed. Ne nulla veritus vel, liber euripidis in eos. Postea comprehensam vis in, detracto deseruisse mei ea. Ex sadipscing deterruisset concludaturque quo.">
-								<img src="/static/img/works/thumbs/11.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/09313311.jpg" data-title="Portfolio title" data-description="Vim ad persecuti appellantur. Eam ignota deterruisset eu, in omnis fierent convenire sed. Ne nulla veritus vel, liber euripidis in eos. Postea comprehensam vis in, detracto deseruisse mei ea. Ex sadipscing deterruisset concludaturque quo.">
+								<img src="static/img/06404511.jpg" alt="img01"/>
 							</a>
             </li>
             <li>
-              <a href="#" data-largesrc="/static/img/works/12.jpg" data-title="Portfolio title" data-description="Mea an eros periculis dignissim, quo mollis nostrum elaboraret et. Id quem perfecto mel, no etiam perfecto qui. No nisl legere recusabo nam, ius an tale pericula evertitur, dicat phaedrum qui in. Usu numquam legendos in, voluptaria sadipscing ut vel. Eu eum mandamus volutpat gubergren, eos ad detracto nominati, ne eum idque elitr aliquam.">
-								<img src="/static/img/works/thumbs/12.jpg" alt="img01"/>
+              <a href="#" data-largesrc="static/img/08064312.jpg" data-title="Portfolio title" data-description="Mea an eros periculis dignissim, quo mollis nostrum elaboraret et. Id quem perfecto mel, no etiam perfecto qui. No nisl legere recusabo nam, ius an tale pericula evertitur, dicat phaedrum qui in. Usu numquam legendos in, voluptaria sadipscing ut vel. Eu eum mandamus volutpat gubergren, eos ad detracto nominati, ne eum idque elitr aliquam.">
+								<img src="static/img/01368612.jpg" alt="img01"/>
 							</a>
             </li>
           </ul>
@@ -273,10 +273,10 @@
       <div class="row">
         <div class="col-md-12">
           <ul class="clients">
-            <li class="wow fadeInDown" data-wow-delay="0.3s"><a href="#"><img src="/static/img/clients/1.png" alt="" /></a></li>
-            <li class="wow fadeInDown" data-wow-delay="0.6s"><a href="#"><img src="/static/img/clients/2.png" alt="" /></a></li>
-            <li class="wow fadeInDown" data-wow-delay="0.9s"><a href="#"><img src="/static/img/clients/3.png" alt="" /></a></li>
-            <li class="wow fadeInDown" data-wow-delay="1.1s"><a href="#"><img src="/static/img/clients/4.png" alt="" /></a></li>
+            <li class="wow fadeInDown" data-wow-delay="0.3s"><a href="#"><img src="static/img/0590311.png" alt="" /></a></li>
+            <li class="wow fadeInDown" data-wow-delay="0.6s"><a href="#"><img src="static/img/0555252.png" alt="" /></a></li>
+            <li class="wow fadeInDown" data-wow-delay="0.9s"><a href="#"><img src="static/img/0519673.png" alt="" /></a></li>
+            <li class="wow fadeInDown" data-wow-delay="1.1s"><a href="#"><img src="static/img/0325254.png" alt="" /></a></li>
           </ul>
         </div>
       </div>
@@ -298,28 +298,28 @@
       <div class="row">
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-3">
           <div class="box-team wow bounceInUp" data-wow-delay="0.1s">
-            <img src="/static/img/team/1.jpg" alt="" class="img-circle img-responsive" />
+            <img src="static/img/0023061.jpg" alt="" class="img-circle img-responsive" />
             <h4>Dominique Vroslav</h4>
             <p>Art Director</p>
           </div>
         </div>
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-3" data-wow-delay="0.3s">
           <div class="box-team wow bounceInUp">
-            <img src="/static/img/team/2.jpg" alt="" class="img-circle img-responsive" />
+            <img src="static/img/0602922.jpg" alt="" class="img-circle img-responsive" />
             <h4>Thomas Jeffersonn</h4>
             <p>Web Designer</p>
           </div>
         </div>
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-3" data-wow-delay="0.5s">
           <div class="box-team wow bounceInUp">
-            <img src="/static/img/team/3.jpg" alt="" class="img-circle img-responsive" />
+            <img src="static/img/0506753.jpg" alt="" class="img-circle img-responsive" />
             <h4>Nola Maurin</h4>
             <p>Illustrator</p>
           </div>
         </div>
         <div class="col-xs-12 col-sm-3 col-md-3 col-lg-3" data-wow-delay="0.7s">
           <div class="box-team wow bounceInUp">
-            <img src="/static/img/team/4.jpg" alt="" class="img-circle img-responsive" />
+            <img src="static/img/0506524.jpg" alt="" class="img-circle img-responsive" />
             <h4>Mira Ladovic</h4>
             <p>Typographer</p>
           </div>
@@ -477,22 +477,22 @@
   <a href="#" class="back-to-top"><i class="fa fa-chevron-up"></i></a>
 
   <!-- js -->
-  <script src="/static/js/jquery.js"></script>
-  <script src="/static/js/bootstrap.min.js"></script>
-  <script src="/static/js/wow.min.js"></script>
-  <script src="/static/js/mb.bgndGallery.js"></script>
-  <script src="/static/js/mb.bgndGallery.effects.js"></script>
-  <script src="/static/js/jquery.simple-text-rotator.min.js"></script>
-  <script src="/static/js/jquery.scrollTo.min.js"></script>
-  <script src="/static/js/jquery.nav.js"></script>
-  <script src="/static/js/modernizr.custom.js"></script>
-  <script src="/static/js/grid.js"></script>
-  <script src="/static/js/stellar.js"></script>
+  <script src="static/js/042316jquery.js"></script>
+  <script src="static/js/077708bootstrap.min.js"></script>
+  <script src="static/js/038689wow.min.js"></script>
+  <script src="static/js/041171mb.bgndGallery.js"></script>
+  <script src="static/js/017057mb.bgndGallery.effects.js"></script>
+  <script src="static/js/076352jquery.simple-text-rotator.min.js"></script>
+  <script src="static/js/073975jquery.scrollTo.min.js"></script>
+  <script src="static/js/024303jquery.nav.js"></script>
+  <script src="static/js/070146modernizr.custom.js"></script>
+  <script src="static/js/054013grid.js"></script>
+  <script src="static/js/076068stellar.js"></script>
   <!-- Contact Form JavaScript File -->
-  <script src="/static/contactform/contactform.js"></script>
+  <script src="static/js/053560contactform.js"></script>
 
   <!-- Template Custom Javascript File -->
-  <script src="/static/js/custom.js"></script>
+  <script src="static/js/039071custom.js"></script>
 
 </body>
 </html>

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -27,7 +27,5 @@ Bootstrap template of choice.
 '''
 
 CONFIGURATION = {
-       'templates_path': os.path.dirname(Example.__file__),
-       'static_path' : os.path.dirname(Example.__file__),
-       'javascript_path' : os.path.join(os.path.dirname(Example.__file__), os.path.basename('js'))
+       'templates_path': r'#'
 }

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -17,6 +17,6 @@ template as it is in the 'Alstar_example'
 '''
 
 CONFIGURATION = {
-       'top_level_path' : r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\startbootstrap-freelancer-gh-pages',
-       'templates_path': r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\startbootstrap-freelancer-gh-pages'
+       'top_level_path' : os.path.dirname(Example.__file__),
+       'templates_path': os.path.dirname(Example.__file__)
 }

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -17,6 +17,6 @@ template as it is in the 'Alstar_example'
 '''
 
 CONFIGURATION = {
-       'top_level_path' : os.path.dirname(Example.__file__),
-       'templates_path': os.path.dirname(Example.__file__)
+       'top_level_path' : r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\startbootstrap-freelancer-gh-pages',
+       'templates_path': r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\startbootstrap-freelancer-gh-pages'
 }

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -27,5 +27,8 @@ Bootstrap template of choice.
 '''
 
 CONFIGURATION = {
-       'templates_path': r'#'
+       'top_level_path' : os.path.dirname(Example.__file__),
+       'templates_path': os.path.dirname(Example.__file__)
 }
+
+#probably need two paths, one to top level and one to the html files

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -2,7 +2,10 @@ import Flaskerizer_src.Examples.Alstar_example as Example
 import os
 
 ''' 
-After unzipping your Bootstrap template, open the template and find the folder that contains the HTML files. Copy the 
+After unzipping your Bootstrap template, copy the path of the unzipped "top level" folder to the 'top_level_path' key
+value in the CONFIGURATION dictionary below.
+ 
+Open the template and find the folder that contains the HTML files. Copy the 
 full path to this folder to the 'templates_path' key value in the CONFIGURATION dictionary below. These HTML files will 
 eventually be migrated to the Flask 'templates' folder by Flaskerizer. 
 
@@ -11,24 +14,9 @@ Choose the one folder that does not contain any rerouting HTML files (hint this 
 HTML files in it). Also note that this 'templates_path' may simply be the top level directory of the bootstrap
 template as it is in the 'Alstar_example'
  
-Next find the folder within the Bootstrap template that contains all the css, javascript, images, etc. Copy the 
-full path to this folder to the 'static_path' key value in the CONFIGURATION dictionary below. These HTML files will 
-eventually be migrated to the Flask 'static' folder by Flaskerizer.
-
-Note that this 'static_path' may also simply be the top level directory of the Bootstrap template as it is in the 
-'Alstar_example'
-
-Finally, find the folder within the Bootstrap template that specifically contains the javascript and copy the full path 
-to this folder to the 'javascript_path' key value in the CONFIGURATION dictionary below.  
-  
-Currently the default 'templates_path', 'static_path', and 'javascript_path' key values are set to reflect paths
-that are correct for the 'Alstar_example', you should replace these values with the paths to your unzipped 
-Bootstrap template of choice. 
 '''
 
 CONFIGURATION = {
-       'top_level_path' : r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\logic-free-html5-multipurpose-business-template',
-       'templates_path': r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\logic-free-html5-multipurpose-business-template'
+       'top_level_path' : os.path.dirname(Example.__file__),
+       'templates_path': os.path.dirname(Example.__file__)
 }
-
-#probably need two paths, one to top level and one to the html files

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -27,8 +27,8 @@ Bootstrap template of choice.
 '''
 
 CONFIGURATION = {
-       'top_level_path' : os.path.dirname(Example.__file__),
-       'templates_path': os.path.dirname(Example.__file__)
+       'top_level_path' : r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\NiceAdmin',
+       'templates_path': r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\NiceAdmin'
 }
 
 #probably need two paths, one to top level and one to the html files

--- a/Flaskerizer_src/config.py
+++ b/Flaskerizer_src/config.py
@@ -27,8 +27,8 @@ Bootstrap template of choice.
 '''
 
 CONFIGURATION = {
-       'top_level_path' : r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\NiceAdmin',
-       'templates_path': r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\NiceAdmin'
+       'top_level_path' : r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\logic-free-html5-multipurpose-business-template',
+       'templates_path': r'C:\Users\vande060\Desktop\coding\projects\Flaskerizer\logic-free-html5-multipurpose-business-template'
 }
 
 #probably need two paths, one to top level and one to the html files

--- a/Flaskerizer_src/gui_for_flaskerizer.py
+++ b/Flaskerizer_src/gui_for_flaskerizer.py
@@ -135,9 +135,8 @@ class ChooseFilesGUI(object):
             return True
 
     def get_values(self):
-        """Gets the html_location, static_location and js_location
-        values for paths to the HTML files, 'static' folder content, and Javascript files of the Bootstrap
-        template. These paths are passed to the StructureDirectory class for flaskerization.
+        """Gets the templates_path and top_level_path values of Bootstrap template.
+        These paths are passed to the StructureDirectory class for flaskerization.
         """
         self.templates = self.templates_path.get()
         self.top_level = self.top_level_path.get()

--- a/Flaskerizer_src/gui_for_flaskerizer.py
+++ b/Flaskerizer_src/gui_for_flaskerizer.py
@@ -25,15 +25,12 @@ class ChooseFilesGUI(object):
     def __init__(self, is_test=False):
         self.root = tk.Tk()
         self.root.title("Flaskerizer")
-        self.html_location = tk.StringVar()
-        self.static_location = tk.StringVar()
-        self.js_location = tk.StringVar()
-        self.html_location.set(
-            "Select one HTML (.html) file from the template")
-        self.static_location.set(
-            "Select the template folder containing all the css, img, js folders")
-        self.js_location.set(
-            "Select one JavaScript (.js) file from the template JavaScript folder")
+        self.templates_path = tk.StringVar()
+        self.top_level_path = tk.StringVar()
+        self.top_level_path.set(
+            "Select the 'top level' folder of the Bootstrap template")
+        self.templates_path.set(
+            "Select one HTML file from the main HTML folder of the Bootstrap template")
         self.main_layout()
         self.is_test = is_test
         if not self.is_test:        #For testing purposes, make it unable to open the window.
@@ -47,55 +44,43 @@ class ChooseFilesGUI(object):
         """
 
         self.main = tk.Frame(self.root)
-        self.label_html = tk.Label(self.main,
-                                   text="HTML File Location:")
-        self.label_html.grid(row=0, column=0, sticky="WENS", pady=20)
-        self.folder_search_html = tk.Button(self.main,
-                                            text="Search Files", command=self.get_html_folder)
-        self.folder_search_html.grid(row=0, column=1, sticky="WENS", pady=20)
-        self.folder_location_html = tk.Entry(self.main,
-                                             textvariable=self.html_location, width=80)
-        self.folder_location_html.grid(row=0, column=2, sticky="WENS", pady=20)
-
 
         self.label_static = tk.Label(self.main,
-                                     text="Static Folder Location:")
-        self.label_static.grid(row=1, column=0, sticky="WENS", pady=20)
+                                     text="Top Level Path Location:")
+        self.label_static.grid(row=0, column=0, sticky="WENS", pady=20)
         self.folder_search_static = tk.Button(self.main,
                                               text="Search Files", command=self.get_static_folder)
-        self.folder_search_static.grid(row=1, column=1, sticky="WENS", pady=20)
+        self.folder_search_static.grid(row=0, column=1, sticky="WENS", pady=20)
         self.folder_location_static = tk.Entry(self.main,
-                                               textvariable=self.static_location, width=80)
-        self.folder_location_static.grid(row=1, column=2, sticky="WENS", pady=20)
+                                               textvariable=self.top_level_path, width=80)
+        self.folder_location_static.grid(row=0, column=2, sticky="WENS", pady=20)
 
-
-        self.label_js = tk.Label(self.main,
-                                 text="JavaScript File Location:")
-        self.label_js.grid(row=2, column=0, sticky="WENS", pady=20)
-        self.folder_search_js = tk.Button(self.main,
-                                          text="Search Files", command=self.get_js_folder)
-        self.folder_search_js.grid(row=2, column=1, sticky="WENS", pady=20)
-        self.folder_location_js = tk.Entry(self.main,
-                                           textvariable=self.js_location, width=80)
-        self.folder_location_js.grid(row=2, column=2, sticky="WENS", pady=20)
-
+        self.label_html = tk.Label(self.main,
+                                   text="Templates Path Location:")
+        self.label_html.grid(row=1, column=0, sticky="WENS", pady=20)
+        self.folder_search_html = tk.Button(self.main,
+                                            text="Search Files", command=self.get_templates_path)
+        self.folder_search_html.grid(row=1, column=1, sticky="WENS", pady=20)
+        self.folder_location_html = tk.Entry(self.main,
+                                             textvariable=self.templates_path, width=80)
+        self.folder_location_html.grid(row=1, column=2, sticky="WENS", pady=20)
 
         self.main.pack()
         self.ok_button = tk.Button(self.root,
                                    text="OK", command=self.get_values).pack()
 
-    def get_html_folder(self):
+    def get_templates_path(self):
         """Opens a file dialog prompting the user to select an HTML file.
         Gets the directory path with the path_to_folder function
         and sets the html_location variable with the returned path value.
         """
 
-        path = filedialog.askopenfilename(title= "Select one HTML (.html) file from the template",
+        path = filedialog.askopenfilename(title= "Select one HTML file from the main HTML folder of the Bootstrap template",
         filetypes=(("Html Files", "*.html"), ("all files", "*.*")))
         if self.validate_path(path) and path.endswith(".html"):
-            self.html_location.set(path)
+            self.templates_path.set(path)
         elif path == "":
-            self.html_location.set("Select one HTML file from the template")
+            self.templates_path.set("Select one HTML file from the main HTML folder of the Bootstrap template")
         elif not path.endswith(".html"):
             messagebox.showinfo("Info", "Please select an HTML (.html) file type.")
 
@@ -104,26 +89,12 @@ class ChooseFilesGUI(object):
         Gets the path, and sets the static_location to the path value.
         """
 
-        path = filedialog.askdirectory(title="Select the template folder containing all the css, img, js folders")
+        path = filedialog.askdirectory(title="Select the 'top level' folder of the Bootstrap template")
         if self.validate_path(path):
-            self.static_location.set(path)
+            self.top_level_path.set(path)
         else:
-            self.static_location.set("Select the template folder containing all the css, img, js folders")
+            self.top_level_path.set("Select the 'top level' folder of the Bootstrap template")
 
-    def get_js_folder(self):
-        """Opens a file dialog prompting the user to select a JavaScript file.
-        Gets the directory path with the path_to_folder function
-        and sets the js_location variable with the returned path value.
-        """
-
-        path = filedialog.askopenfilename(title = "Select one JavaScript (.js) file from the template JavaScript folder",
-        filetypes=(("JavaScript Files", "*.js"), ("all files", "*.*")))
-        if self.validate_path(path) and path.endswith(".js"):
-            self.js_location.set(path)
-        elif path == "":
-            self.js_location.set("Select one JavaScript (.js) file from the template JavaScript folder")
-        elif not path.endswith(".js"):
-            messagebox.showinfo("Info", "Please select a JavaScript (.js) file type.")
 
 
     def path_to_folder(self, path):
@@ -149,21 +120,17 @@ class ChooseFilesGUI(object):
         """
 
         self.error_entries = []
-        html = self.validate_path(self.html_location.get())
-        static = self.validate_path(self.static_location.get())
-        js = self.validate_path(self.js_location.get())
+        html = self.validate_path(self.templates_path.get())
+        static = self.validate_path(self.top_level_path.get())
         if not html:
             self.error_entries.append("'Html File location' ")
-        if not static:
-            self.error_entries.append("'Static Files location' ")
-        if not js:
-            self.error_entries.append("'JavaScript File location' ")
-        if not html or not static or not js:
             self.error_message = "There are errors in the following entries: "
             for x in self.error_entries:
-                self.error_message = self.error_message + x 
+                self.error_message = self.error_message + x
             messagebox.showerror("Entries Error", self.error_message)
             return False
+        if not static:
+            self.error_entries.append("'Top level folder location' ")
         else:
             return True
 
@@ -172,21 +139,16 @@ class ChooseFilesGUI(object):
         values for paths to the HTML files, 'static' folder content, and Javascript files of the Bootstrap
         template. These paths are passed to the StructureDirectory class for flaskerization.
         """
-        self.html = self.html_location.get()
-        self.static = self.static_location.get()
-        self.js = self.js_location.get()
+        self.templates = self.templates_path.get()
+        self.top_level = self.top_level_path.get()
         if not self.is_test:        #For testing purposes making the program unable to make new folders or windows.
             if self.validate_entries():
-                self.html = self.path_to_folder(self.html)
-                self.js = self.path_to_folder(self.js)
+                self.templates = self.path_to_folder(self.templates)
                 self.root.quit()
-                self.structure_directory_object = StructureDirectory(templates_path=self.html,
-                                                                    static_path=self.static,
-                                                                    javascript_path=self.js)
+                self.structure_directory_object = StructureDirectory(templates_path=self.templates,
+                                                                     top_level_path=self.top_level)
                 self.write_app_object = WriteApp()
-                self.structure_directory_object.migrate_static()
-                self.structure_directory_object.parse_html()
-                self.structure_directory_object.parse_javascript()
+                self.structure_directory_object.structure_directory()
                 self.write_app_object.write_app()
-        return [self.html, self.static, self.js]        #For testing purposes returns values
+        return [self.templates, self.top_level]        #For testing purposes returns values
 

--- a/Flaskerizer_src/structure_directory.py
+++ b/Flaskerizer_src/structure_directory.py
@@ -95,7 +95,7 @@ class StructureDirectory():
 
 
     def load_file(self, file):
-        '''Iterates through each file in a file_list returned ny the "file_list" method and loads them into memory as a
+        '''Iterates through each file in a file_list returned by the "file_list" method and loads them into memory as a
         list containing an item for each line of the file.
         '''
         line_list = []
@@ -107,7 +107,7 @@ class StructureDirectory():
 
     def parse_links(self, migrate_dict):
         '''Iterates through every file returned by the "file_list" method and
-        adds /static/ to any line that should point to contents of the static folder of the flask app (i.e. lines that
+        adds /static/ to any line that should point to contents of the static folder of the Flask app (i.e. lines that
         reference content of the css or javascript folder etc.).
         '''
         file_list = self.file_list()

--- a/Flaskerizer_src/structure_directory.py
+++ b/Flaskerizer_src/structure_directory.py
@@ -106,11 +106,11 @@ class StructureDirectory():
         file_list = self.file_list()
         for file in file_list:
             line_list = []
-            with open(file, 'r', encoding='utf-8') as read_obj: #there are encoding issues here
+            with io.open(file, 'r', encoding='utf-8') as read_obj: #there are encoding issues here
                 for line in read_obj:
                     line_list.append(line)
             os.remove(file)
-            with open(file, 'a', encoding='utf-8') as write_obj:
+            with io.open(file, 'a', encoding='utf-8') as write_obj:
                 for line in line_list:
                     for name in migrate_dict:
                         if migrate_dict[name]['link'] in line:

--- a/Flaskerizer_src/structure_directory.py
+++ b/Flaskerizer_src/structure_directory.py
@@ -8,8 +8,11 @@ import shutil
 
 class StructureDirectory():
     def __init__(self, templates_path, top_level_path):
-        ''' The templates_path attribute of the StructureDirectory class is a path to the HTML
-        files in the Bootstrap template source folder that will be migrated to the Flask 'templates' folder.
+        '''
+        The top_level_path attribute of the StructureDirectory class is a path to the top level folder
+         of the Bootstrap template source folder. The templates_path attribute of the StructureDirectory class is a
+         path to the HTML files in the Bootstrap template source folder that will be migrated to the Flask 'templates'
+        folder.
         '''
         self.top_level_path = top_level_path
         self.templates_path = templates_path
@@ -68,7 +71,8 @@ class StructureDirectory():
                     if name.endswith(extension):
                         migrate_dict[name] = {'source_dir': '', 'link' : ''}
                         migrate_dict[name]['source_dir'] = os.path.join(path, name)
-                        migrate_dict[name]['link'] = os.path.join(path, name).replace('\\', '/')[len(self.templates_path) + 1:]
+                        migrate_dict[name]['link'] = os.path.join(path, name).replace('\\',
+                                                                                      '/')[len(self.templates_path) + 1:]
         return migrate_dict
 
     def detect_and_migrate_html_files(self):
@@ -82,28 +86,31 @@ class StructureDirectory():
                                              os.path.basename('templates'),
                                              os.path.basename(file_name)))
 
-
-
-    def parse_links(self, migrate_dict):
-        '''Iterates through every line of each file (key) of the migrate_dict and
-        adds /static/ to any line that should point to contents of the static folder of the flask app (i.e. lines that
-        reference content of the css or javascript folder etc.).
+    def file_list(self):
+        '''Returns a list of JavaScript and HTML files that need to be parsed for broken links by the "parse_links method.
         '''
         file_list = []
         templates_dir = os.path.join(self.flaskerized_app_dir, os.path.basename('templates'))
         js_dir = os.path.join(self.flaskerized_app_dir, os.path.basename('static'), os.path.basename('js'))
-
         for html in os.listdir(templates_dir):
             file_list.append(os.path.join(templates_dir, os.path.basename(html)))
         for js in os.listdir(js_dir):
             file_list.append(os.path.join(js_dir, os.path.basename(js)))
+        return file_list
+
+    def parse_links(self, migrate_dict):
+        '''Iterates through every file returned by the "file_list" method and
+        adds /static/ to any line that should point to contents of the static folder of the flask app (i.e. lines that
+        reference content of the css or javascript folder etc.).
+        '''
+        file_list = self.file_list()
         for file in file_list:
             line_list = []
-            with open(file, 'r') as read_obj: #there are encoding issues here
+            with open(file, 'r', encoding='utf-8') as read_obj: #there are encoding issues here
                 for line in read_obj:
                     line_list.append(line)
             os.remove(file)
-            with open(file, 'a') as write_obj:
+            with open(file, 'a', encoding='utf-8') as write_obj:
                 for line in line_list:
                     for name in migrate_dict:
                         if migrate_dict[name]['link'] in line:

--- a/Flaskerizer_src/structure_directory.py
+++ b/Flaskerizer_src/structure_directory.py
@@ -87,15 +87,16 @@ class StructureDirectory():
                                              os.path.basename(file_name)))
 
     def file_list(self):
-        '''Returns a list of JavaScript and HTML files that need to be parsed for broken links by the "parse_links method.
+        '''Returns a list of JavaScript, CSS, and HTML files that need to be parsed for broken links by the
+        "parse_links method.
         '''
         file_list = []
-        templates_dir = os.path.join(self.flaskerized_app_dir, os.path.basename('templates'))
-        js_dir = os.path.join(self.flaskerized_app_dir, os.path.basename('static'), os.path.basename('js'))
-        for html in os.listdir(templates_dir):
-            file_list.append(os.path.join(templates_dir, os.path.basename(html)))
-        for js in os.listdir(js_dir):
-            file_list.append(os.path.join(js_dir, os.path.basename(js)))
+        for extension in ['html', 'js', 'css']:
+            extension_dir = os.path.join(self.flaskerized_app_dir,
+                                         os.path.basename(target_folders[extension]['folder']),
+                                         os.path.basename(target_folders[extension]['subfolder']))
+        for file in os.listdir(extension_dir):
+            file_list.append(os.path.join(extension_dir, os.path.basename(file)))
         return file_list
 
     def parse_links(self, migrate_dict):

--- a/Flaskerizer_src/structure_directory.py
+++ b/Flaskerizer_src/structure_directory.py
@@ -1,100 +1,58 @@
 import io #needed to backport some open statements to python 2.7
 import os
 from Flaskerizer_src.config import CONFIGURATION
+from Flaskerizer_src.target_folders import target_folders
 import flaskerizer
 import random
 import shutil
 
 class StructureDirectory():
-    def __init__(self, templates_path):
+    def __init__(self, templates_path, top_level_path):
         ''' The templates_path attribute of the StructureDirectory class is a path to the HTML
-        files in the Bootstrap template source folder that will be migrated to the Flask 'templates' folder. The
-        static_path attribute of the StructureDirectory class is a path to the css, javascript, images, fonts, etc.
-        content of the Bootstrap template source folder that will be migrated to the Flask 'static' folder.
+        files in the Bootstrap template source folder that will be migrated to the Flask 'templates' folder.
         '''
+        self.top_level_path = top_level_path
         self.templates_path = templates_path
+        self.flaskerized_app_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
+                                        os.path.basename('Flaskerized_app'))
 
-
-    def mkdir(self, folder, subfolder):
+    def mkdir(self):
         '''Makes folder of dir name in the Flaskerized_app directory.
         '''
-        dir_path = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                os.path.basename('Flaskerized_app'),
-                                os.path.basename(folder),
-                                os.path.basename(subfolder))
-        if not os.path.exists(dir_path):
-            print('generating {} folder'.format(folder))
-            os.makedirs(dir_path)
-        else:
-            print('overwriting old {} folder'.format(folder))
-            shutil.rmtree(os.path.join(os.path.dirname(flaskerizer.__file__),
-                                       os.path.basename('Flaskerized_app'),
-                                       os.path.basename(folder),
-                                       os.path.basename(subfolder)))
-            os.makedirs(dir_path)
-
-    def make_folders(self):
-        folders = {'templates' : [''],
-                   'static' : ['js', 'css', 'img', 'fonts']
+        folders = {'templates': [''],
+                   'static': ['js', 'css', 'img', 'fonts']
                    }
         for folder, subfolders in folders.items():
             for subfolder in subfolders:
-                self.mkdir(folder, subfolder)
+                dir_path = os.path.join(self.flaskerized_app_dir,
+                                        os.path.basename(folder),
+                                        os.path.basename(subfolder))
+                if not os.path.exists(dir_path):
+                    os.makedirs(dir_path)
+                else:
+                    shutil.rmtree(dir_path)
+                    os.makedirs(dir_path)
+
 
     def migrate_files(self, migrate_dict):
-        target_folders = {
-            'html' : {'folder': 'templates',
-                      'subfolder' : ''
-                      },
-            'js': {'folder': 'static',
-                      'subfolder' : 'js'
-                   },
-            'css': {'folder': 'static',
-                      'subfolder' : 'css'
-                    },
-            'jpg': {'folder': 'static',
-                      'subfolder' : 'img'
-                    },
-            'png': {'folder': 'static',
-                      'subfolder' : 'img'
-                    },
-            'ico': {'folder': 'static',
-                      'subfolder' : 'img'
-                    },
-            'otf': {'folder': 'static',
-                      'subfolder' : 'fonts'
-                    },
-            'eot': {'folder': 'static',
-                      'subfolder' : 'fonts'
-                    },
-            'svg': {'folder': 'static',
-                      'subfolder' : 'fonts'
-                    },
-            'ttf': {'folder': 'static',
-                      'subfolder' : 'fonts'
-                    },
-            'woff': {'folder': 'static',
-                      'subfolder' : 'fonts'
-                    },
-            'woff2': {'folder': 'static',
-                      'subfolder' : 'fonts'
-                    },
-        }
+        '''Migration of all files detected by the detect_files method to their appropriate destinations in the
+        Flaskerized_app directory (i.e. files with .css extension migrated to the css subfolder of the static folder.)
+        '''
         for name in migrate_dict:
             item_extension = name.split('.')[-1]
             shutil.copyfile(migrate_dict[name]['source_dir'],
-                            os.path.join(os.path.dirname(flaskerizer.__file__),
-                                         os.path.basename('Flaskerized_app'),
+                            os.path.join(self.flaskerized_app_dir,
                                          os.path.basename(target_folders[item_extension]['folder']),
                                          os.path.basename(target_folders[item_extension]['subfolder']),
                                          os.path.basename(name)))
-
-
-
-    def search_tree(self):
+    def detect_static_files(self):
+        '''Walks through the entire directory tree of the Bootstrap template detecting any files with extensions that
+        are needed for the static content of the Flask app (i.e. .css, .js, .img, etc). The names and locations of
+        these files are saved in a dictionary.
+        '''
         migrate_dict = {}
-        extensions = ['.html', '.js', '.css', '.jpg', '.png', '.ico', '.otf', '.eot', '.svg', '.ttf', '.woff', '.woff2']
-        path = self.templates_path
+        extensions = ['.js', '.css', '.jpg', '.png', '.ico', '.otf', '.eot', '.svg', '.ttf', '.woff', '.woff2']
+        path = self.top_level_path
         for path, subdir, files in os.walk(path):
             for name in files:
                 if name in migrate_dict:
@@ -104,83 +62,75 @@ class StructureDirectory():
                             migrate_dict[duplicate_name] = {'source_dir': '', 'link': ''}
                             migrate_dict[duplicate_name]['source_dir'] = os.path.join(path, name)
                             migrate_dict[duplicate_name]['link'] = os.path.join(path, name).replace('\\', '/')[
-                                                         len(self.templates_path) + 1:]
+                                                         len(self.top_level_path) + 1:]
                     continue
                 for extension in extensions:
                     if name.endswith(extension):
                         migrate_dict[name] = {'source_dir': '', 'link' : ''}
                         migrate_dict[name]['source_dir'] = os.path.join(path, name)
                         migrate_dict[name]['link'] = os.path.join(path, name).replace('\\', '/')[len(self.templates_path) + 1:]
+        return migrate_dict
 
-        self.migrate_files(migrate_dict)
-        self.parse_links(migrate_dict)
+    def detect_and_migrate_html_files(self):
+        '''Detects files with the extension ".html" in the templates_path. These files are migrated to the "templates"
+        folder of the Flaskerized_app directory.
+        '''
+        for file_name in os.listdir(self.templates_path):
+            if file_name.endswith('.html'):
+                shutil.copyfile(os.path.join(self.templates_path, os.path.basename(file_name)),
+                                os.path.join(self.flaskerized_app_dir,
+                                             os.path.basename('templates'),
+                                             os.path.basename(file_name)))
+
+
 
     def parse_links(self, migrate_dict):
-        '''Iterates through every line in the html_content of an HTML document with the filename 'file_name' and
+        '''Iterates through every line of each file (key) of the migrate_dict and
         adds /static/ to any line that should point to contents of the static folder of the flask app (i.e. lines that
         reference content of the css or javascript folder etc.).
         '''
         file_list = []
-        templates_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                                      os.path.basename('Flaskerized_app'),
-                                                      os.path.basename('templates'))
-        js_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                                      os.path.basename('Flaskerized_app'),
-                                                      os.path.basename('static'),
-                                                      os.path.basename('js'))
-        css_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                                      os.path.basename('Flaskerized_app'),
-                                                      os.path.basename('static'),
-                                                      os.path.basename('css'))
+        templates_dir = os.path.join(self.flaskerized_app_dir, os.path.basename('templates'))
+        js_dir = os.path.join(self.flaskerized_app_dir, os.path.basename('static'), os.path.basename('js'))
 
         for html in os.listdir(templates_dir):
             file_list.append(os.path.join(templates_dir, os.path.basename(html)))
         for js in os.listdir(js_dir):
             file_list.append(os.path.join(js_dir, os.path.basename(js)))
-        for css in os.listdir(css_dir):
-            file_list.append(os.path.join(css_dir, os.path.basename(css)))
         for file in file_list:
             line_list = []
-            with io.open(file, 'r') as read_obj:
+            with open(file, 'r') as read_obj: #there are encoding issues here
                 for line in read_obj:
                     line_list.append(line)
             os.remove(file)
-            with io.open(file, 'a') as write_obj:
+            with open(file, 'a') as write_obj:
                 for line in line_list:
                     for name in migrate_dict:
                         if migrate_dict[name]['link'] in line:
                             if name.endswith('.html'):
                                 line = line.replace(migrate_dict[name]['link'], name)
-                            elif name.endswith('.js'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/js/' + name)
-                            elif name.endswith('.css'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/css/' + name)
-                            elif name.endswith('.jpg'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/img/' + name)
-                            elif name.endswith('.png'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/img/' + name)
-                            elif name.endswith('.ico'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/img/' + name)
-                            elif name.endswith('.otf'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
-                            elif name.endswith('.eot'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
-                            elif name.endswith('.svg'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
-                            elif name.endswith('.ttf'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
-                            elif name.endswith('.woff'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
-                            elif name.endswith('.woff2'):
-                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
-#'711.jpg': {'source_dir': 'C:\\Users\\vande060\\Desktop\\coding\\projects\\Flaskerizer\\Flaskerizer_src\\Examples\\Alstar_example\\img\\parallax\\1.jpg', 'link': 'img/parallax/1.jpg'}
-
+                            else:
+                                for extension in target_folders:
+                                    if name.endswith(extension):
+                                        line = line.replace(migrate_dict[name]['link'],
+                                                            '/'.join((target_folders[extension]['folder'],
+                                                                      target_folders[extension]['subfolder'], name)))
                     write_obj.write(line)
 
+    def structure_directory(self):
+        self.mkdir()
+        migrate_dict = self.detect_static_files()
+        self.migrate_files(migrate_dict)
+        self.detect_and_migrate_html_files()
+        self.parse_links(migrate_dict)
+
+
 if __name__ == "__main__":
-    my_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'])
-    my_object.make_folders()
-    my_object.search_tree()
+    my_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'],
+                                   top_level_path=CONFIGURATION['top_level_path'])
+    my_object.structure_directory()
+
+
 
 
 

--- a/Flaskerizer_src/structure_directory.py
+++ b/Flaskerizer_src/structure_directory.py
@@ -2,125 +2,185 @@ import io #needed to backport some open statements to python 2.7
 import os
 from Flaskerizer_src.config import CONFIGURATION
 import flaskerizer
+import random
 import shutil
 
 class StructureDirectory():
-    def __init__(self, templates_path, static_path, javascript_path):
+    def __init__(self, templates_path):
         ''' The templates_path attribute of the StructureDirectory class is a path to the HTML
         files in the Bootstrap template source folder that will be migrated to the Flask 'templates' folder. The
         static_path attribute of the StructureDirectory class is a path to the css, javascript, images, fonts, etc.
         content of the Bootstrap template source folder that will be migrated to the Flask 'static' folder.
         '''
         self.templates_path = templates_path
-        self.static_path = static_path
-        self.javascript_path = javascript_path
 
-    def mkdir(self, dir):
+
+    def mkdir(self, folder, subfolder):
         '''Makes folder of dir name in the Flaskerized_app directory.
         '''
         dir_path = os.path.join(os.path.dirname(flaskerizer.__file__),
                                 os.path.basename('Flaskerized_app'),
-                                os.path.basename(dir))
+                                os.path.basename(folder),
+                                os.path.basename(subfolder))
         if not os.path.exists(dir_path):
-            print('generating {} folder'.format(dir))
+            print('generating {} folder'.format(folder))
             os.makedirs(dir_path)
         else:
-            print('overwriting old {} folder'.format(dir))
+            print('overwriting old {} folder'.format(folder))
             shutil.rmtree(os.path.join(os.path.dirname(flaskerizer.__file__),
                                        os.path.basename('Flaskerized_app'),
-                                       os.path.basename(dir)))
+                                       os.path.basename(folder),
+                                       os.path.basename(subfolder)))
             os.makedirs(dir_path)
 
-    def migrate_javascript(self, javascript_obj, file_name):
-        '''Iterates through every line in the javascript files of the source Bootstrap template and
-        adds /static/ to any line that should point to contents of the static folder of the flask app (i.e. lines that
-        reference images in the 'static' folder)
-        '''
-        js_folder_name = os.path.basename(self.javascript_path)
-        write_directory = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                       os.path.basename('Flaskerized_app'),
-                                       os.path.basename('static'),
-                                       os.path.basename(js_folder_name))
-        with io.open(os.path.join(write_directory, file_name), 'w', encoding='utf-8') as write_obj:
-            for line in javascript_obj.readlines():
-                for folder in os.listdir(os.path.join(os.path.dirname(flaskerizer.__file__),
-                                                      os.path.basename('Flaskerized_app'),
-                                                      os.path.basename('static'))):
-                    if ('\"' + str(folder) + "/") in line:
-                        split_line = line.split("\"" + str(folder) + "/")
-                        line = ("\"" + 'static/' + (str(folder) + "/")).join(split_line)
-                    elif ('\'' + str(folder) + "/") in line:
-                        split_line = line.split("\'" + str(folder) + "/")
-                        line = ("\'" + 'static/' + (str(folder) + "/")).join(split_line)
-                write_obj.write(line)
+    def make_folders(self):
+        folders = {'templates' : [''],
+                   'static' : ['js', 'css', 'img', 'fonts']
+                   }
+        for folder, subfolders in folders.items():
+            for subfolder in subfolders:
+                self.mkdir(folder, subfolder)
 
-    def parse_javascript(self):
-        '''Locates all the javascript files in the Bootstrap template directory.
-        '''
-        for file_name in os.listdir(self.javascript_path):
-            if '.js' in file_name:
-                print('generating content for {} and migrating content to templates folder'.format(file_name))
-                source_directory = os.path.join(self.javascript_path, os.path.basename(file_name))
-                with io.open(source_directory, 'r', encoding='utf-8') as javascript_obj:
-                    self.migrate_javascript(javascript_obj, file_name)
+    def migrate_files(self, migrate_dict):
+        target_folders = {
+            'html' : {'folder': 'templates',
+                      'subfolder' : ''
+                      },
+            'js': {'folder': 'static',
+                      'subfolder' : 'js'
+                   },
+            'css': {'folder': 'static',
+                      'subfolder' : 'css'
+                    },
+            'jpg': {'folder': 'static',
+                      'subfolder' : 'img'
+                    },
+            'png': {'folder': 'static',
+                      'subfolder' : 'img'
+                    },
+            'ico': {'folder': 'static',
+                      'subfolder' : 'img'
+                    },
+            'otf': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'eot': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'svg': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'ttf': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'woff': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'woff2': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+        }
+        for name in migrate_dict:
+            item_extension = name.split('.')[-1]
+            shutil.copyfile(migrate_dict[name]['source_dir'],
+                            os.path.join(os.path.dirname(flaskerizer.__file__),
+                                         os.path.basename('Flaskerized_app'),
+                                         os.path.basename(target_folders[item_extension]['folder']),
+                                         os.path.basename(target_folders[item_extension]['subfolder']),
+                                         os.path.basename(name)))
 
-    def migrate_static(self):
-        '''Makes a static folder then migrates all the folders from the bootstrap template directory that belong in
-        the static folder (css, js, etc) to the newly made static folder.
-        '''
-        self.mkdir('static')
-        for item in os.listdir(self.static_path):
-            item_path = os.path.join(self.static_path, os.path.basename(item))
-            if os.path.isdir(item_path):
-                print('migrating {} to static folder'.format(item))
-                shutil.copytree(item_path,
-                                os.path.join(os.path.dirname(flaskerizer.__file__),
-                                             os.path.basename('Flaskerized_app'),
-                                             os.path.basename('static'),
-                                             os.path.basename(item)))
 
-    def migrate_templates(self, html_content, file_name):
+
+    def search_tree(self):
+        migrate_dict = {}
+        extensions = ['.html', '.js', '.css', '.jpg', '.png', '.ico', '.otf', '.eot', '.svg', '.ttf', '.woff', '.woff2']
+        path = self.templates_path
+        for path, subdir, files in os.walk(path):
+            for name in files:
+                if name in migrate_dict:
+                    duplicate_name = str(random.randint(1,100)) + name
+                    for extension in extensions:
+                        if name.endswith(extension):
+                            migrate_dict[duplicate_name] = {'source_dir': '', 'link': ''}
+                            migrate_dict[duplicate_name]['source_dir'] = os.path.join(path, name)
+                            migrate_dict[duplicate_name]['link'] = os.path.join(path, name).replace('\\', '/')[
+                                                         len(self.templates_path) + 1:]
+                    continue
+                for extension in extensions:
+                    if name.endswith(extension):
+                        migrate_dict[name] = {'source_dir': '', 'link' : ''}
+                        migrate_dict[name]['source_dir'] = os.path.join(path, name)
+                        migrate_dict[name]['link'] = os.path.join(path, name).replace('\\', '/')[len(self.templates_path) + 1:]
+
+        self.migrate_files(migrate_dict)
+        self.parse_links(migrate_dict)
+
+    def parse_links(self, migrate_dict):
         '''Iterates through every line in the html_content of an HTML document with the filename 'file_name' and
         adds /static/ to any line that should point to contents of the static folder of the flask app (i.e. lines that
         reference content of the css or javascript folder etc.).
         '''
-        write_directory = os.path.join(os.path.dirname(flaskerizer.__file__),
-                                       os.path.basename('Flaskerized_app'),
-                                       os.path.basename('templates'),
-                                       os.path.basename(file_name))
-        for line in html_content:
-            with io.open(write_directory, 'a') as write_obj:
-                for folder in os.listdir(os.path.join(os.path.dirname(flaskerizer.__file__),
+        file_list = []
+        templates_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
                                                       os.path.basename('Flaskerized_app'),
-                                                      os.path.basename('static'))):
-                    if ('=\"' + str(folder) + "/") in line or ('=\"../' + str(folder) + "/") in line:
-                        split_line = line.replace('../', '').split("\"" + str(folder) + "/")
-                        line = ("\"" + '/static/' + (str(folder) + "/")).join(split_line)
-                    elif ('\"./' + str(folder) + "/") in line:
-                        split_line = line.split("\"./" + str(folder) + "/")
-                        line = ("\"./" + 'static/' + (str(folder) + "/")).join(split_line)
-                    elif ('url(' + str(folder) + "/") in line:
-                        split_line = line.split('url(' + str(folder) + "/")
-                        line = ('url(' + 'static/' + (str(folder) + "/")).join(split_line)
-                write_obj.write(line)
+                                                      os.path.basename('templates'))
+        js_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
+                                                      os.path.basename('Flaskerized_app'),
+                                                      os.path.basename('static'),
+                                                      os.path.basename('js'))
+        css_dir = os.path.join(os.path.dirname(flaskerizer.__file__),
+                                                      os.path.basename('Flaskerized_app'),
+                                                      os.path.basename('static'),
+                                                      os.path.basename('css'))
 
-    def parse_html(self):
-        '''Locates all the HTML files in the Bootstrap template directory.
-        '''
-        self.mkdir('templates')
-        for file_name in os.listdir(self.templates_path):
-            if '.html' in file_name:
-                print('generating content for {} and migrating content to templates folder'.format(file_name))
-                source_directory = os.path.join(self.templates_path, os.path.basename(file_name))
-                with io.open(source_directory, 'r') as html_content:
-                    self.migrate_templates(html_content, file_name)
+        for html in os.listdir(templates_dir):
+            file_list.append(os.path.join(templates_dir, os.path.basename(html)))
+        for js in os.listdir(js_dir):
+            file_list.append(os.path.join(js_dir, os.path.basename(js)))
+        for css in os.listdir(css_dir):
+            file_list.append(os.path.join(css_dir, os.path.basename(css)))
+        for file in file_list:
+            line_list = []
+            with io.open(file, 'r') as read_obj:
+                for line in read_obj:
+                    line_list.append(line)
+            os.remove(file)
+            with io.open(file, 'a') as write_obj:
+                for line in line_list:
+                    for name in migrate_dict:
+                        if migrate_dict[name]['link'] in line:
+                            if name.endswith('.html'):
+                                line = line.replace(migrate_dict[name]['link'], name)
+                            elif name.endswith('.js'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/js/' + name)
+                            elif name.endswith('.css'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/css/' + name)
+                            elif name.endswith('.jpg'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/img/' + name)
+                            elif name.endswith('.png'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/img/' + name)
+                            elif name.endswith('.ico'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/img/' + name)
+                            elif name.endswith('.otf'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
+                            elif name.endswith('.eot'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
+                            elif name.endswith('.svg'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
+                            elif name.endswith('.ttf'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
+                            elif name.endswith('.woff'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
+                            elif name.endswith('.woff2'):
+                                line = line.replace(migrate_dict[name]['link'], 'static/fonts/' + name)
+#'711.jpg': {'source_dir': 'C:\\Users\\vande060\\Desktop\\coding\\projects\\Flaskerizer\\Flaskerizer_src\\Examples\\Alstar_example\\img\\parallax\\1.jpg', 'link': 'img/parallax/1.jpg'}
+
+                    write_obj.write(line)
 
 if __name__ == "__main__":
-    my_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'],
-                                   static_path=CONFIGURATION['static_path'],
-                                   javascript_path=CONFIGURATION['javascript_path'])
-    my_object.migrate_static()
-    my_object.parse_html()
-    my_object.parse_javascript()
+    my_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'])
+    my_object.make_folders()
+    my_object.search_tree()
+
 
 

--- a/Flaskerizer_src/target_folders.py
+++ b/Flaskerizer_src/target_folders.py
@@ -40,4 +40,4 @@ target_folders = {
                     },
         }
 
-#migrate fonts to fonts and css subfolder!
+#ToDo fonts also need to be migrated to the css subfolder of static

--- a/Flaskerizer_src/target_folders.py
+++ b/Flaskerizer_src/target_folders.py
@@ -14,6 +14,9 @@ target_folders = {
             'png': {'folder': 'static',
                       'subfolder' : 'img'
                     },
+            'gif' : {'folder' : 'static',
+                     'subfolder' : 'img'},
+
             'ico': {'folder': 'static',
                       'subfolder' : 'img'
                     },
@@ -36,3 +39,5 @@ target_folders = {
                       'subfolder' : 'fonts'
                     },
         }
+
+#migrate fonts to fonts and css subfolder!

--- a/Flaskerizer_src/target_folders.py
+++ b/Flaskerizer_src/target_folders.py
@@ -1,0 +1,38 @@
+target_folders = {
+            'html' : {'folder': 'templates',
+                      'subfolder' : ''
+                      },
+            'js': {'folder': 'static',
+                      'subfolder' : 'js'
+                   },
+            'css': {'folder': 'static',
+                      'subfolder' : 'css'
+                    },
+            'jpg': {'folder': 'static',
+                      'subfolder' : 'img'
+                    },
+            'png': {'folder': 'static',
+                      'subfolder' : 'img'
+                    },
+            'ico': {'folder': 'static',
+                      'subfolder' : 'img'
+                    },
+            'otf': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'eot': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'svg': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'ttf': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'woff': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+            'woff2': {'folder': 'static',
+                      'subfolder' : 'fonts'
+                    },
+        }

--- a/Flaskerizer_src/write_app.py
+++ b/Flaskerizer_src/write_app.py
@@ -12,7 +12,7 @@ class WriteApp():
                                                                  os.path.basename('Flaskerized_app'),
                                                                  os.path.basename('templates')))]
 
-    def write_error_handler(self, template_name, write_obj):#ToDo eliminate non-error status codes from dictionary
+    def write_error_handler(self, template_name, write_obj):
         '''If the write_routes function detects a template name as containing a status code, the template name will
         be passed to write_error_handler along with the write_obj. The write_error_handler function will write an
         error handler for the template, which is making the assumption that the template was intended to represent

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Flask: 0.12.1 or higher
 
 2. Install dependencies by opening a terminal in top level directory of the repo and entering `$ pip install -r requirements.txt` 
 
-3. Download your favorite Bootstrap template from https://Bootstrapmade.com/ .Note that there is an example template (Alstar_example) that you can use if you don't want to download one. 
+3. Download your favorite Bootstrap template. Note that there is an example template (Alstar_example) that you can use if you don't want to download one. 
 
 4. If the Bootstrap template is downloaded as a zipped file you will need to unzip the Bootstrap template
 
@@ -69,7 +69,7 @@ The Flasker has two main classes:
 
 **The StructureDirectory class**
 
-The StructureDirectory class makes the typical Flask project folder structure in the Flaskerized_app directory. This includes making a 'static' folder that will contain all the front end files from the Bootstrap template (css, javascript, etc.) and a 'templates' folder that will contain all the HTML files from the Bootstrap template. The StructureDirectory class takes both the full path to Bootstrap template HTML files (templates_path) and the full path to the top level directory of the Bootstrap template as arguments. HTML files are copied from the Bootstrap template to the Flask project folder from explicitly stated templates_path. Methods of the StructureDirectory class search the entire Bootstrap template directory tree for any files that belong in the 'static' folder based on their extensions (.js, .css, .img, etc). Any files that belong in the 'static' folder of the Flask project are thenn migrated there. The StructureDirectory class also has methods that parse all migrated files for links that refer to original folder structure of the Bootstrap template and fixes them to reflect the new structure of the Flask project. 
+The StructureDirectory class makes the typical Flask project folder structure in the Flaskerized_app directory. This includes making a 'static' folder that will contain all the front end files from the Bootstrap template (css, javascript, etc.) and a 'templates' folder that will contain all the HTML files from the Bootstrap template. The StructureDirectory class takes both the full path to Bootstrap template HTML files (templates_path) and the full path to the top level directory of the Bootstrap template (top_level_path) as arguments. HTML files are copied from the Bootstrap template to the Flask project folder from explicitly stated templates_path. Methods of the StructureDirectory class search the entire Bootstrap template directory tree for any files that belong in the 'static' folder based on their extensions (.js, .css, .img, etc). Any files that belong in the 'static' folder of the Flask project are then migrated there. The StructureDirectory class also has methods that parse all migrated files for links that refer to original folder structure of the Bootstrap template and fixes them to reflect the new structure of the Flask project. 
 
 **The WriteApp class**
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## What is the Flaskerizer and what problem does it solve?
 
-Bootstrap templates from websites like https://Bootstrapmade.com/ and https://startBootstrap.com are a fast way to get very dynamic website up and running, but Bootstap templates typically don't work "out of the box" with the python web framework Flask and require some tedious directory building and broken link fixing before being functional with Flask. This is especially true if the Bootstrap templates are for large multi-page websites. 
+Free Bootstrap templates from websites like https://Bootstrapmade.com/ and https://startBootstrap.com are a fast way to get very dynamic website up and running, but Bootstap templates typically don't work "out of the box" with the python web framework Flask and require some tedious directory building and broken link fixing before being functional with Flask. This is especially true if the Bootstrap templates are for large multi-page websites. 
 
 The Flaskerizer automates the necessary directory building and link creation needed to make Bootstrap templates work "out of the box" with Flask. The Flaskerizer also automatically creates a python script with the appropriate routes and basic error handling needed to serve the Bootstrap template as a Flask app.
 
@@ -34,14 +34,16 @@ Flask: 0.12.1 or higher
 5. Open the Configuration file(`config.py`) and:
 
 * set value of key *'top_level_path'* to the full path of the top level folder of the Bootstrap template (i.e. the folder that appears when you first unzip the Bootstrap template, see config.py for example).
+
+* set value of key *templates_path* to the full path of the folder containing the HTML files of the Bootstrap template you downloaded. Note that there may be multiple folders that contain HTML files, generally you want to set the 'templates_path' value equal to the path of the folder with the *most* HTML files in it (see config.py for example).
  
-6. Run the program by opening a terminal in the top level directory of the repo and entering `$ python flaskerizer.py` (this may vary slightly by environment)
+6. Run the program by opening a terminal in the top level directory of the repo and entering `$ python flaskerizer.py` (this may vary slightly by environment and may take a few minutes to run depending on the Bootstrap template size)
 
 7. After running flaskerizer.py, clear your browser's cache and enter `$ python Flaskerized_app/app.py` in the terminal to launch the newly made Flask app.
 
 8. View your website by opening the browser to your local address on port 5000 (i.e. http://127.0.0.1:5000 / http://0.0.0.0:5000) , Note: may have to enter http://127.0.0.1:5000/index.html / http://0.0.0.0:5000/index.html to route the  website homepage.
 
-9. You may get still get a few 404 errors for broken links that you might need to fix manually, the Flaskerizer is not perfect yet, but overall it seems to be doing a good job. The best things you can do if you get broken link errors is to raise an issue with us and specify the template you are using so that we can fix it. You can also email me at brett.vanderwerff@gmail.com
+9. You may get still get a few 404 errors for broken links that you might need to fix manually, the Flaskerizer is early in development and not perfect yet, but overall it seems to be doing a good job regardless of the Bootstrap template source. The best things you can do if you get broken link errors is to raise an issue with us and specify the template you are using and the error you are getting so that we can try to fix it. You can also email me at brett.vanderwerff@gmail.com
 
 - **NOTE :** You may need to clear your browser's cache to view the website properly (I'm not sure why this happens sometimes)
 
@@ -69,7 +71,7 @@ The Flasker has two main classes:
 
 **The StructureDirectory class**
 
-The StructureDirectory class makes the typical Flask project folder structure in the Flaskerized_app directory. This includes making a 'static' folder that will contain all the front end files from the Bootstrap template (css, javascript, etc.) and a 'templates' folder that will contain all the HTML files from the Bootstrap template. The StructureDirectory class takes both the full path to Bootstrap template HTML files (templates_path) and the full path to the top level directory of the Bootstrap template (top_level_path) as arguments. HTML files are copied from the Bootstrap template to the Flask project folder from explicitly stated templates_path. Methods of the StructureDirectory class search the entire Bootstrap template directory tree for any files that belong in the 'static' folder based on their extensions (.js, .css, .img, etc). Any files that belong in the 'static' folder of the Flask project are then migrated there. The StructureDirectory class also has methods that parse all migrated files for links that refer to original folder structure of the Bootstrap template and fixes them to reflect the new structure of the Flask project. 
+The StructureDirectory class makes the typical Flask project folder structure in the Flaskerized_app directory. This includes making a 'static' folder that will contain all the front end files from the Bootstrap template (css, javascript, etc.) and a 'templates' folder that will contain all the HTML files from the Bootstrap template. The StructureDirectory class takes both the full path to Bootstrap template HTML files (templates_path) and the full path to the top level directory of the Bootstrap template (top_level_path) as arguments. HTML files are copied from the Bootstrap template to the Flask project folder via the explicitly stated templates_path. Methods of the StructureDirectory class search the entire Bootstrap template directory tree for any files that belong in the 'static' folder based on their extensions (.js, .css, .img, etc). Any files that belong in the 'static' folder of the Flask project are then migrated there. The StructureDirectory class also has methods that parse all migrated files for links that refer to original folder structure of the Bootstrap template and fixes them to reflect the new structure of the Flask project. 
 
 **The WriteApp class**
 

--- a/README.md
+++ b/README.md
@@ -33,18 +33,15 @@ Flask: 0.12.1 or higher
 
 5. Open the Configuration file(`config.py`) and:
 
-* set value of key *templates_path* to the full path of the folder containing the HTML files of the Bootstrap template you downloaded. Note that there may be multiple folders that contain HTML files, generally you want to set the 'templates_path' value equal to the path of the folder with the *most* HTML files in it (see config.py for example).
-
-* set value of key *static_path* to the full path of the folder containing the css, javascript, images, etc. folders of the Bootstrap template you downloaded (see config.py for example).
-
-* set value of key *javascript_path* to the full path of the folder specifically containing the javascript files of the Bootstrap template you downloaded (see config.py for example).
-
+* set value of key *'top_level_path'* to the full path of the top level folder of the Bootstrap template (i.e. the folder that appears when you first unzip the Bootstrap template, see config.py for example).
  
 6. Run the program by opening a terminal in the top level directory of the repo and entering `$ python flaskerizer.py` (this may vary slightly by environment)
 
 7. After running flaskerizer.py, clear your browser's cache and enter `$ python Flaskerized_app/app.py` in the terminal to launch the newly made Flask app.
 
 8. View your website by opening the browser to your local address on port 5000 (i.e. http://127.0.0.1:5000 / http://0.0.0.0:5000) , Note: may have to enter http://127.0.0.1:5000/index.html / http://0.0.0.0:5000/index.html to route the  website homepage.
+
+9. You may get still get a few 404 errors for broken links that you might need to fix manually, the Flaskerizer is not perfect yet, but overall it seems to be doing a good job. The best things you can do if you get broken link errors is to raise an issue with us and specify the template you are using so that we can fix it. You can also email me at brett.vanderwerff@gmail.com
 
 - **NOTE :** You may need to clear your browser's cache to view the website properly (I'm not sure why this happens sometimes)
 
@@ -72,36 +69,21 @@ The Flasker has two main classes:
 
 **The StructureDirectory class**
 
-The StructureDirectory class makes the typical Flask project folder structure in the Flaskerized_app directory. This includes making a 'static' folder that will contain all the front end files from the Bootstrap template (css, javascript, etc.) and a 'templates' folder that will contain all the HTML files from the Bootstrap template. The StructureDirectory class takes both the full path to Bootstrap template HTML files (templates_path) and the full path to the css, javascript, images, etc. folders of the Bootstrap template (static_path) as arguments.  
-
-The StructureDirectory class has 3 main methods:
-
-`migrate_static`:
-
-The migrate_static method creates a 'static' folder in the Flaskerized_app directory. All the folders from the designated 'static_path' (see config.py) of the Bootstrap template will be copied to the newly made 'static' folder in the Flaskerized_app directory. The assumption is made that all folders in the Bootstrap template contain the front end information that belongs in the 'static' folder like css, javascript, images, etc. This may not always be the case, but often it is. 
-
-`parse_html`:
-
-The parse_html method creates a 'templates' folder in the Flaskerized_app directory. The string content of all the HTML files from the designated 'templates_path' (see config.py) of the Bootstrap template are parsed for any links that references the content placed in the 'static' folder by the migrate_static method. If any links are found, they are modified to reflect the correct structure of the Flask application. This avoids broken links that would otherwise incorrectly reference files in the 'static' folder. Once the HTML files are parsed and corrected, they are written to the newly made 'templates' folder in the Flaskerized_app directory.
-
-`parse_javascript`:
-
-Similar to the parse_html method, the parse_javascript method iterates through the string content of all the javascript files from the designated 'javascript_path' (see config.py) of the Bootstrap template in search of links that reference the content placed in the 'static' folder by the migrate_static method. If any links are found, they are modified to reflect the correct structure of the Flask application. Once the javascript files are parsed and corrected, they are written to the newly made 'static' folder in the appropriate subdirectory of the Flaskerized_app folder.
+The StructureDirectory class makes the typical Flask project folder structure in the Flaskerized_app directory. This includes making a 'static' folder that will contain all the front end files from the Bootstrap template (css, javascript, etc.) and a 'templates' folder that will contain all the HTML files from the Bootstrap template. The StructureDirectory class takes both the full path to Bootstrap template HTML files (templates_path) and the full path to the top level directory of the Bootstrap template as arguments. HTML files are copied from the Bootstrap template to the Flask project folder from explicitly stated templates_path. Methods of the StructureDirectory class search the entire Bootstrap template directory tree for any files that belong in the 'static' folder based on their extensions (.js, .css, .img, etc). Any files that belong in the 'static' folder of the Flask project are thenn migrated there. The StructureDirectory class also has methods that parse all migrated files for links that refer to original folder structure of the Bootstrap template and fixes them to reflect the new structure of the Flask project. 
 
 **The WriteApp class**
 
 
-The WriteApp class has one main method:
 
-`write_app`:
-
-The write_app method automatically writes a python script 'app.py' with the necessary instructions to launch a Flask app of the Bootstrap template. This method writes the import statements, instantiates the 'app' object from the Flask class, and writes a main loop to run the app. This method also detects the HTML files in the 'templates' folder and writes the corresponding routes to these HTML files. If any of the HTML files are named for an HTTP status code, the write_app method generates an error handling route for that file. This assumes that any HTML file with an HTTP status code in it's name reflects an error, which is usually true. 
+Methods of the WriteApp class automatically write a python script 'app.py' with the necessary instructions to launch a Flask app of the Bootstrap template. The methods write the import statements, instantiate the 'app' object from the Flask class, and write a main loop to run the app. This methods also detect the HTML files in the 'templates' folder of the Flask project and write the corresponding routes to these HTML files. If any of the HTML files are named for an HTTP status code, the methods generate an error handling route for that file. This assumes that any HTML file with an HTTP status code in it's name reflects an error, which is usually true. 
 
 
 ## Contribution Guidelines
 
+We are beginner friendly.
+
 1. Comment on an issue you would like assigned to you. 
-2. Fork the Flaskerizer repo onto your github.
+2. Fork the Flaskerizer repo onto your Github.
 3. Clone your fork to your machine.
 4. Use git to make a new branch on your local machine by opening a terminal and typing `$ git checkout -b XXXX-SHORT_TITLE_OF_ISSUE` where XXX is the zero padded issue number, such as 0001. For example: `$ git checkout -b 0001-HTTP_STATUS_CODE_ISSUE` would be good for the first issue in the repo. 
 5. Make a pull request right away by pushing your branch to github and trying to merge your fork with my master branch. It's okay if you have not made any progress, just title the pull request whatever you titled the branch and add 'Work in progress" to the title so that I know you are working on it. 

--- a/flaskerizer.py
+++ b/flaskerizer.py
@@ -11,9 +11,8 @@ from Flaskerizer_src.config import CONFIGURATION
 from Flaskerizer_src.structure_directory import StructureDirectory
 from Flaskerizer_src.write_app import WriteApp
 
-structure_directory_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'])
-structure_directory_object.make_folders()
-structure_directory_object.search_tree()
+structure_directory_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'], top_level_path=CONFIGURATION['top_level_path'])
+structure_directory_object.structure_directory()
 write_app_object = WriteApp()
 write_app_object.write_app()
 

--- a/flaskerizer.py
+++ b/flaskerizer.py
@@ -11,13 +11,10 @@ from Flaskerizer_src.config import CONFIGURATION
 from Flaskerizer_src.structure_directory import StructureDirectory
 from Flaskerizer_src.write_app import WriteApp
 
-structure_directory_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'],
-                                                static_path=CONFIGURATION['static_path'],
-                                                javascript_path=CONFIGURATION['javascript_path'])
+structure_directory_object = StructureDirectory(templates_path=CONFIGURATION['templates_path'])
+structure_directory_object.make_folders()
+structure_directory_object.search_tree()
 write_app_object = WriteApp()
+write_app_object.write_app()
 
-if __name__ == '__main__':
-    structure_directory_object.migrate_static()
-    structure_directory_object.parse_html()
-    structure_directory_object.parse_javascript()
-    write_app_object.write_app()
+


### PR DESCRIPTION
This is a big WIP fix that addresses #51 and #50 by making flaskerizer parse bootstrap template directory tree to locate all the files that go in static and templates automatically based on extension names. This circumvents having the user need to point to js etc folders manually. The hope is that this PR will make the Flaskerizer work with almost any bootstrap template regardless of original folder structures